### PR TITLE
Fix snippet generator for waitUntil step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep.java
@@ -53,7 +53,7 @@ public final class WaitForConditionStep extends Step {
         this.initialRecurrencePeriod = Math.max(MIN_RECURRENCE_PERIOD, Math.min(initialRecurrencePeriod, MAX_RECURRENCE_PERIOD));
     }
 
-    long getInitialRecurrencePeriod() {
+    public long getInitialRecurrencePeriod() {
         return initialRecurrencePeriod;
     }
 
@@ -62,7 +62,7 @@ public final class WaitForConditionStep extends Step {
         this.quiet = quiet;
     }
 
-    boolean getQuiet() { return quiet; }
+    public boolean getQuiet() { return quiet; }
 
     @Override public StepExecution start(StepContext context) throws Exception {
         return new Execution(context, initialRecurrencePeriod, this.quiet);

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep/config.jelly
@@ -25,7 +25,10 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry field="initialRecurrencePeriod" title="Initial Recurrence Period Milliseconds">
+    <f:entry field="initialRecurrencePeriod" title="${%Initial Recurrence Period Milliseconds}">
         <f:number clazz="positive-number"/>
+    </f:entry>
+    <f:entry field="quiet" title="${%Quiet Mode}">
+        <f:checkbox checked="false"/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep/help-quiet.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep/help-quiet.html
@@ -1,0 +1,3 @@
+<div>
+    If true, the step does not log a message each time the condition is checked. Defaults to false.
+</div>


### PR DESCRIPTION
I didn't notice earlier, but the snippet generator was broken for this step (even before your PR). I fixed that issue and also updated it to support the new parameter. Here is the error that the snippet generator was throwing previously:

```
no public field ‘initialRecurrencePeriod’ (or getter method) found in class org.jenkinsci.plugins.workflow.steps.WaitForConditionStep
```